### PR TITLE
Add JobSetup CronJob

### DIFF
--- a/kustomize/base/grafana/instance/datasource-setup-job.yaml
+++ b/kustomize/base/grafana/instance/datasource-setup-job.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: datasource-setup-cronjob
+spec:
+  schedule: "0 */12 * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      generateName: datasource-setup-
+    spec:
+      parallelism: 1
+      completions: 1
+      suspend: false
+      template:
+        spec:
+          serviceAccountName: grafana-thanos
+          restartPolicy: Never
+          containers:
+            - name: datasource-setup-script
+              image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+              args:
+                - /script/script.sh
+              resources:
+                limits:
+                  memory: "128Mi"
+                  cpu: "500m"
+              volumeMounts:
+                - mountPath: /script
+                  name: script-cm
+                - mountPath: /var/run/secrets/tokens
+                  name: thanos-token
+          volumes:
+            - name: script-cm
+              configMap:
+                defaultMode: 0777
+                name: datasource-setup-script
+            - name: thanos-token
+              projected:
+                sources:
+                  - serviceAccountToken:
+                      path: thanos-token
+                      expirationSeconds: 86400

--- a/kustomize/base/grafana/instance/datasource-setup-job.yaml
+++ b/kustomize/base/grafana/instance/datasource-setup-job.yaml
@@ -22,7 +22,7 @@ spec:
             - name: datasource-setup-script
               image: image-registry.openshift-image-registry.svc:5000/openshift/cli
               args:
-                - /script/script.sh
+                - /script/sa-token-datasource-patch.sh
               resources:
                 limits:
                   memory: "128Mi"
@@ -43,3 +43,41 @@ spec:
                   - serviceAccountToken:
                       path: thanos-token
                       expirationSeconds: 86400
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: grafana-setup-
+spec:
+  parallelism: 1
+  completions: 1
+  suspend: false
+  template:
+    spec:
+      serviceAccountName: grafana-thanos
+      restartPolicy: Never
+      containers:
+        - name: setup-scripts
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+          args:
+            - /script/setup.sh
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          volumeMounts:
+            - mountPath: /script
+              name: script-cm
+            - mountPath: /var/run/secrets/tokens
+              name: thanos-token
+      volumes:
+        - name: script-cm
+          configMap:
+            defaultMode: 0777
+            name: setup-scripts
+        - name: thanos-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: thanos-token
+                  expirationSeconds: 86400

--- a/kustomize/base/grafana/instance/datasource-setup-job.yaml
+++ b/kustomize/base/grafana/instance/datasource-setup-job.yaml
@@ -60,7 +60,7 @@ spec:
         - name: setup-scripts
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli
           args:
-            - /script/setup.sh
+            - /script/sa-token-datasource-patch.sh
           resources:
             limits:
               memory: "128Mi"

--- a/kustomize/base/grafana/instance/datasource-setup-jobonly.yaml
+++ b/kustomize/base/grafana/instance/datasource-setup-jobonly.yaml
@@ -14,7 +14,7 @@ spec:
         - name: setup-scripts
           image: image-registry.openshift-image-registry.svc:5000/openshift/cli
           args:
-            - /script/setup.sh
+            -  /script/sa-token-datasource-patch.sh
           resources:
             limits:
               memory: "128Mi"

--- a/kustomize/base/grafana/instance/datasource-setup-jobonly.yaml
+++ b/kustomize/base/grafana/instance/datasource-setup-jobonly.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: grafana-setup-
+spec:
+  parallelism: 1
+  completions: 1
+  suspend: false
+  template:
+    spec:
+      serviceAccountName: grafana-thanos
+      restartPolicy: Never
+      containers:
+        - name: setup-scripts
+          image: image-registry.openshift-image-registry.svc:5000/openshift/cli
+          args:
+            - /script/setup.sh
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          volumeMounts:
+            - mountPath: /script
+              name: script-cm
+      volumes:
+        - name: script-cm
+          configMap:
+            defaultMode: 0777
+            name: setup-scripts

--- a/kustomize/base/grafana/instance/kustomization.yaml
+++ b/kustomize/base/grafana/instance/kustomization.yaml
@@ -7,9 +7,11 @@ resources:
   # - grafana-readonly.yaml
   - grafana-admin.yaml
   - grafana-datasource.yaml
+  ## OCP 4.11
   - datasource-setup-job.yaml
-
+  ## OCP 4.10
+  # - datasource-setup-jobonly.yaml
 configMapGenerator:
   - name: datasource-setup-script
     files:
-      - script.sh
+      - sa-token-datasource-patch.sh

--- a/kustomize/base/grafana/instance/kustomization.yaml
+++ b/kustomize/base/grafana/instance/kustomization.yaml
@@ -2,10 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- session-secret.yaml
-- ocp-injected-certs.yaml
-# - grafana-readonly.yaml
-- grafana-admin.yaml
-- grafana-datasource.yaml
+  - session-secret.yaml
+  - ocp-injected-certs.yaml
+  # - grafana-readonly.yaml
+  - grafana-admin.yaml
+  - grafana-datasource.yaml
+  - datasource-setup-job.yaml
 
-  
+configMapGenerator:
+  - name: datasource-setup-script
+    files:
+      - script.sh

--- a/kustomize/base/grafana/instance/sa-token-datasource-patch.sh
+++ b/kustomize/base/grafana/instance/sa-token-datasource-patch.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-TOKEN=$(cat /var/run/secrets/tokens/thanos-token)
+TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+
+if [ -e /var/run/secrets/tokens/thanos-token]; then
+    TOKEN=$(cat /var/run/secrets/tokens/thanos-token)
+fi
+
 PATCH="[{\"op\": \"replace\", \"path\":\"/spec/datasources/0/secureJsonData/httpHeaderValue1\", \"value\": \"Bearer ${TOKEN}\"}]"
 
 set +x

--- a/kustomize/base/grafana/instance/script.sh
+++ b/kustomize/base/grafana/instance/script.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TOKEN=$(cat /var/run/secrets/tokens/thanos-token)
+PATCH="[{\"op\": \"replace\", \"path\":\"/spec/datasources/0/secureJsonData/httpHeaderValue1\", \"value\": \"Bearer ${TOKEN}\"}]"
+
+set +x
+oc patch grafanadatasources thanos -n $(cat /run/secrets/kubernetes.io/serviceaccount/namespace) --type json --patch "${PATCH}"

--- a/kustomize/base/grafana/instance/setup-job-sa-binding.yaml
+++ b/kustomize/base/grafana/instance/setup-job-sa-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grafana-thanos
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafanadatasources.integreatly.org-v1alpha1-admin
+subjects:
+  - kind: ServiceAccount
+    name: grafana-thanos

--- a/kustomize/env/grafana-monitoring-operator/grafana-cluster-monitoring-view.yaml
+++ b/kustomize/env/grafana-monitoring-operator/grafana-cluster-monitoring-view.yaml
@@ -7,5 +7,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-monitoring-view
 subjects:
-- kind: ServiceAccount
-  name: grafana-thanos
+  - kind: ServiceAccount
+    name: grafana-thanos
+    namespace: grafanatest

--- a/kustomize/env/grafana-monitoring-operator/grafana-cluster-monitoring-view.yaml
+++ b/kustomize/env/grafana-monitoring-operator/grafana-cluster-monitoring-view.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: grafana-thanos
-    namespace: grafanatest

--- a/kustomize/env/grafana-monitoring-operator/operator-group.yaml
+++ b/kustomize/env/grafana-monitoring-operator/operator-group.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: self
+  name: grafanatest-og
 spec:
   targetNamespaces:
-  - grafana-monitoring
+    - grafanatest

--- a/kustomize/env/grafana-monitoring-operator/operator-group.yaml
+++ b/kustomize/env/grafana-monitoring-operator/operator-group.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: grafanatest-og
+  name: self
 spec:
   targetNamespaces:
-    - grafanatest
+    - grafana-monitoring


### PR DESCRIPTION
This Adds the CronJob for 4.11 to keep the service account token in updated.

Notes:
Every time the cronjob runs,  grafana restarts.  In this reference instance, it is non-destructive,  but it could be if non-saved dashboards are created.
Also,  there is nothing to force the cronjob to run as soon as its loaded,  so it may be necessary to do it by hand when created
